### PR TITLE
Missing quote to close data-divido-amount

### DIFF
--- a/Resources/views/frontend/detail/content/buy_container.tpl
+++ b/Resources/views/frontend/detail/content/buy_container.tpl
@@ -28,7 +28,7 @@
               data-divido-plans="{$sArticle.divido_finance_plans|replace:'|':','}"
               {$prefix}
               {$suffix}
-              data-divido-amount="{$sArticle.price|replace:',':'.'}
+              data-divido-amount="{$sArticle.price|replace:',':'.'}"
               data-divido-apply="true"
               data-divido-apply-label="Apply Now"
               >


### PR DESCRIPTION
Apparently the code has been like this forever. Completely missed it this whole week. It's evidently never broken anything, but might be best to close the quotes off